### PR TITLE
changed SetFavoritePokemonMessage pokemon_id to uint64

### DIFF
--- a/proto/POGOProtos.Networking.Requests.Messages.proto
+++ b/proto/POGOProtos.Networking.Requests.Messages.proto
@@ -182,7 +182,7 @@ message SetContactSettingsMessage {
 	.POGOProtos.Data.Player.ContactSettings contact_settings = 1;
 }
 message SetFavoritePokemonMessage {
-	fixed64 pokemon_id = 1;
+	uint64 pokemon_id = 1;
 	bool is_favorite = 2;
 }
 message SetPlayerTeamMessage {


### PR DESCRIPTION
For some reason when the pokemon_id is set to fixed64, the API returns with the result of 2 which is **ERROR_POKEMON_NOT_FOUND** ([File proof](https://github.com/cyraxx/node-pogo-protos/blob/ab3b18bdc437e622bbf1428bb09bcfeb15903325/proto/POGOProtos.Networking.Responses.proto#L447)) when passed a Pokemon ID.  However, when set to uint64, it works.

Same type of idea here: https://github.com/tejado/pgoapi/issues/59 and https://github.com/PokemonGoF/PokemonGo-Bot/issues/452#issuecomment-234920567

Setting nickname does work, so no worries there.
